### PR TITLE
Check for existence of 'assister' event variable

### DIFF
--- a/addons/source-python/plugins/warcraft/calls.py
+++ b/addons/source-python/plugins/warcraft/calls.py
@@ -38,7 +38,7 @@ def _on_kill_assist_call_events(event_data):
     attacker = players.from_userid(event_data['attacker'])
     victim = players.from_userid(event_data['userid'])
     assister = None
-    if event_data['assister']:
+    if 'assister' in event_data.variables and event_data['assister']:
         assister = players.from_userid(event_data['assister'])
 
     attacker.hero.call_events('player_kill', player=attacker, victim=victim,

--- a/addons/source-python/plugins/warcraft/experience.py
+++ b/addons/source-python/plugins/warcraft/experience.py
@@ -32,7 +32,7 @@ def _on_kill_assist_give_experience(event_data):
 
     attacker = players.from_userid(event_data['attacker'])
     assister = None
-    if event_data['assister']:
+    if 'assister' in event_data.variables and event_data['assister']:
         assister = players.from_userid(event_data['assister'])
 
     attacker.hero.give_experience(WARCRAFT_KILL_EXPERIENCE)


### PR DESCRIPTION
Prevents KeyError exception when running on older games such as cs:source