### PR TITLE
Removed extra parameters from give_named_item call

### DIFF
--- a/addons/source-python/plugins/warcraft/warcraft.py
+++ b/addons/source-python/plugins/warcraft/warcraft.py
@@ -77,7 +77,7 @@ def _on_spawn_check_hero_requirement(event_data):
 def _on_level_change(hero):
     player = hero.owner
     spend_skills.send(player)
-    pointer = player.give_named_item('env_smokestack', 0, None, False)
+    pointer = player.give_named_item('env_smokestack')
     entity = Entity(index_from_pointer(pointer))
 
     Model('effects/yellowflare.vmt')


### PR DESCRIPTION
These were unneeded, as they were simply set to the default value for csgo. Additionally the last two parameters differ between games.

CSGO
```python
def give_named_item(self, item, sub_type=0, econ_item_view=None, unk=False):
```

Orange Box
```python
def give_named_item(self, item, sub_type=0):
```

L4D2
```python
def give_named_item(self, item, sub_type=0, unk1=False, unk2=None):
```

BM:S (Black Mesa: Source i assume)
```python
def give_named_item(self, item, sub_type=0, primary_ammo=-1,
```

