### PR TITLE
Remove sqlite files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Files created by the plugin
+/addons/source-python/plugins/warcraft/database/players.sqlite
+
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Files created by the plugin
-/addons/source-python/plugins/warcraft/database/players.sqlite
-
+*.sqlite
+*.sqlite-journal
 
 # Windows image file caches
 Thumbs.db


### PR DESCRIPTION
The file does not need to be included, as it is automatically created when the plugin is run and it is empty. It also counts as a changed file if you run the plugin directly from your local clone.

Added both *.sqlite and *.sqlite-journal to .gitignore, as i assume neither is going to be needed in git.