### PR TITLE
Fix ValueError when c4 breaks props

### DIFF
--- a/addons/source-python/plugins/warcraft/calls.py
+++ b/addons/source-python/plugins/warcraft/calls.py
@@ -62,11 +62,15 @@ def _on_kill_assist_call_events(event_data):
     'round_mvp', 'silencer_on', 'silencer_off', 'weapon_fire', 'weapon_fire_on_empty',
     'weapon_reload', 'weapon_zoom')
 def _on_personal_call_events(event_data):
-    player = players.from_userid(event_data['userid'])
-    if player.index == 0 or player.userid == 0:
+    userid = event_data['userid']
+    if userid == 0:
         return
-    kwargs = event_data.variables.as_dict()
 
+    player = players.from_userid(userid)
+    if player.index == 0:
+        return
+
+    kwargs = event_data.variables.as_dict()
     player.hero.call_events(event_data.name, player=player, **kwargs)
 
 @Event('player_hurt')


### PR DESCRIPTION
When the bomb explodes it can break props, which results in it trying to get the player with userid 0.
Fx on de_dust2 bombsite A, there is a breakable lid in the corner towards short, which causes this issue.


```
break_prop
userid 0
entindex 108

[SP] Caught an Exception:
Traceback (most recent call last):
  File "..\addons\source-python\packages\source-python\events\listener.py", line 92, in fire_game_event
    callback(game_event)
  File "..\addons\source-python\plugins\warcraft\calls.py", line 69, in _on_personal_call_events
    player = players.from_userid(event_data['userid'])
  File "..\addons\source-python\packages\source-python\players\dictionary.py", line 39, in from_userid
    return self[index_from_userid(userid)]

ValueError: Conversion from "Userid" (0) to "Index" failed.
```